### PR TITLE
Use string in (new Message())->setFrom()

### DIFF
--- a/Message.php
+++ b/Message.php
@@ -120,8 +120,14 @@ class Message extends BaseMessage
     /**
      * @inheritdoc
      */
-    public function setFrom($from)
+    public function setFrom($from, $name = null)
     {
+        if (!isset($name)) {
+            $name = gethostbyaddr($_SERVER['SERVER_ADDR']);
+        }
+        if (!is_array($from) && isset($name)) {
+            $from = array($from => $name);
+        }
         list($address) = array_keys($from);
         $name = $from[$address];
         $this->from = '"'.$name.'" <'.$address.'>';

--- a/Message.php
+++ b/Message.php
@@ -123,7 +123,7 @@ class Message extends BaseMessage
     public function setFrom($from, $name = null)
     {
         if (!isset($name)) {
-            $name = gethostbyaddr($_SERVER['SERVER_ADDR']);
+            $name = gethostname();
         }
         if (!is_array($from) && isset($name)) {
             $from = array($from => $name);


### PR DESCRIPTION
Examples for using the Yii mailer sets a string in the setFrom function. However, the original setfrom in this repo requires an array. If given a string, it gives a PHP Notice for array_keys function. This pull request takes snippets from https://github.com/swiftmailer/swiftmailer/blob/master/lib/classes/Swift/Mime/SimpleMessage.php#L207 to convert any string to array before using it. In addition, it also sets the local hostname if name is not set.